### PR TITLE
Add easy layout sharing

### DIFF
--- a/coxraidscouter/src/main/java/net/runelite/client/plugins/coxraidscouter/coxraidscouterconfig.java
+++ b/coxraidscouter/src/main/java/net/runelite/client/plugins/coxraidscouter/coxraidscouterconfig.java
@@ -97,6 +97,28 @@ public interface coxraidscouterconfig extends Config {
     }
 
     @ConfigItem(
+            position = 8,
+            keyName = "SendLayoutToCC",
+            name = "Send layout to cc",
+            description = "Sends the layout to cc when a raid is found."
+    )
+    default boolean SendLayoutToCC()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+        position = 8,
+        keyName = "RespondToLayoutRequest",
+        name = "Respond to layout request",
+        description = "Sends the layout to cc when someone types ?l in cc."
+    )
+    default boolean RespondToLayoutRequest()
+    {
+        return true;
+    }
+
+    @ConfigItem(
             position = 9,
             keyName = "debugScouting",
             name = "Debug Scouting",


### PR DESCRIPTION
Add config option for the scouter to send layout into cc when a raid is found.
Add config option to respond to `?L` message in cc by sending layout in cc.